### PR TITLE
<feat>Implementación del listado de votaciones abiertas

### DIFF
--- a/decide/base/static/decide/css/voting/voting.css
+++ b/decide/base/static/decide/css/voting/voting.css
@@ -1,0 +1,9 @@
+.titulo {
+    margin-top: 60px;
+}
+
+.mensajes {
+    font-size: 16px !important;
+    margin-top: -5px;
+    margin-bottom: 50px;
+}

--- a/decide/base/templates/base.html
+++ b/decide/base/templates/base.html
@@ -122,7 +122,7 @@
                                     </div>
                                 </form>
                             </li>
-                            <li><a href="/booth/1/">Booth</a></li>
+                            <li><a href="/voting/openVotings/">{% trans 'Open Votings' %}</a></li>
                             <li><a href="#">Link 2</a></li>
                             <li><a href="/admin"><img class="admin-icon" src="{% static 'decide/img/django_icon.png'%}"/></a></li>
                             {% endblock %}

--- a/decide/base/templates/base.html
+++ b/decide/base/templates/base.html
@@ -122,7 +122,7 @@
                                     </div>
                                 </form>
                             </li>
-                            <li><a href="/voting/openVotings/">{% trans 'Open Votings' %}</a></li>
+                            <li><a href="/voting/openVotings/">{% trans 'Open votings' %}</a></li>
                             <li><a href="#">Link 2</a></li>
                             <li><a href="/admin"><img class="admin-icon" src="{% static 'decide/img/django_icon.png'%}"/></a></li>
                             {% endblock %}

--- a/decide/booth/templates/booth/booth.html
+++ b/decide/booth/templates/booth/booth.html
@@ -22,7 +22,7 @@
     {% elif voting.end_date != None %}
         <p class="center-align flow-text descripcion">{% trans 'The voting can not be accessed because it has ended. You can access to the results in the following link: ' %} <a href="/visualizer/{{voting.id}}">{% trans 'Results' %}</a></p>
     {% elif voting.questions|length == 0 %}
-        <p class="center-align flow-text descripcion">{% trans 'This vote does not contain any questions, so it can not be accessed yet. Try it again later.' %}</p>
+        <p class="center-align flow-text descripcion">{% trans 'This voting does not contain any questions, so it can not be accessed yet. Try it again later.' %}</p>
     {% else %}
   
     <div id="voting">

--- a/decide/locale/ca/LC_MESSAGES/django.po
+++ b/decide/locale/ca/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-09 19:00+0100\n"
+"POT-Creation-Date: 2019-01-10 11:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,370 +17,417 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-#: .\decide\authentication\forms.py:13
+
+#: .\authentication\forms.py:13
 msgid "Man"
 msgstr "Homes"
 
-#: .\decide\authentication\forms.py:14
+#: .\authentication\forms.py:14
 msgid "Woman"
 msgstr "dona"
 
-#: .\decide\authentication\forms.py:15
+#: .\authentication\forms.py:15
 msgid "Non-binary"
 msgstr "No binari"
 
-#: .\decide\authentication\forms.py:17
+#: .\authentication\forms.py:17
 msgid "Format: dd/mm/YYYY"
 msgstr "Format: dd/mm/AAAA"
 
-#: .\decide\authentication\forms.py:19 .\decide\authentication\models.py:17
+#: .\authentication\forms.py:19 .\authentication\models.py:17
 msgid "First name"
 msgstr "Nom"
 
-#: .\decide\authentication\forms.py:20 .\decide\authentication\models.py:18
+#: .\authentication\forms.py:20 .\authentication\models.py:18
 msgid "Last name"
 msgstr "Cognom"
 
-#: .\decide\authentication\forms.py:21 .\decide\authentication\models.py:16
-#: .\decide\authentication\serializers.py:16
-#: .\decide\authentication\templates\authentication\login.html:37
+#: .\authentication\forms.py:21 .\authentication\models.py:16
+#: .\authentication\serializers.py:16
+#: .\authentication\templates\authentication\login.html:37
 msgid "Email"
 msgstr "Correu electrònic"
 
-#: .\decide\authentication\forms.py:22 .\decide\authentication\models.py:19
+#: .\authentication\forms.py:22 .\authentication\models.py:19
 msgid "Birthdate"
 msgstr "Data de naixement"
 
-#: .\decide\authentication\forms.py:23 .\decide\authentication\models.py:20
+#: .\authentication\forms.py:23 .\authentication\models.py:20
 msgid "City"
 msgstr "Ciutat"
 
-#: .\decide\authentication\forms.py:24 .\decide\authentication\models.py:21
+#: .\authentication\forms.py:24 .\authentication\models.py:21
 msgid "Sex"
 msgstr "Sexe"
 
-#: .\decide\authentication\forms.py:54
+#: .\authentication\forms.py:54
 msgid "Email alredy exits"
 msgstr "Correu electrònic de sortida"
 
-#: .\decide\authentication\forms.py:64
+#: .\authentication\forms.py:64
 msgid "Future date not posible"
 msgstr "La data futura no és possible"
 
-#: .\decide\authentication\models.py:22
+#: .\authentication\models.py:22
 msgid "Is active"
 msgstr "Està actiu"
 
-#: .\decide\authentication\models.py:23
+#: .\authentication\models.py:23
 msgid "Is staf"
 msgstr "És staf"
 
-#: .\decide\authentication\schemas\inspectors.py:114
+#: .\authentication\schemas\inspectors.py:114
 msgid "unique integer value"
 msgstr "unique integer value"
 
-#: .\decide\authentication\schemas\inspectors.py:116
+#: .\authentication\schemas\inspectors.py:116
 msgid "UUID string"
 msgstr "UUID string"
 
-#: .\decide\authentication\schemas\inspectors.py:118
+#: .\authentication\schemas\inspectors.py:118
 msgid "unique value"
 msgstr "unique value"
 
-#: .\decide\authentication\schemas\inspectors.py:120
+#: .\authentication\schemas\inspectors.py:120
 #, python-brace-format
 msgid "A {value_type} identifying this {name}."
 msgstr "A {value_type} identifying this {name}."
 
-#: .\decide\authentication\serializers.py:18
-#: .\decide\authentication\templates\authentication\login.html:45
+#: .\authentication\serializers.py:18
+#: .\authentication\templates\authentication\login.html:45
 msgid "Password"
 msgstr "Contrasenya"
 
-#: .\decide\authentication\serializers.py:32
+#: .\authentication\serializers.py:32
 msgid "Unable to log in with provided credentials."
 msgstr "No es pot iniciar sessió amb les credencials proporcionades."
 
-#: .\decide\authentication\serializers.py:35
+#: .\authentication\serializers.py:35
 msgid "Must include \"email\" and \"password\"."
 msgstr "Ha d'incloure \"correu electrònic\" i \"contrasenya\"."
 
-#: .\decide\authentication\templates\authentication\acc_active_email.html:3
-#: .\decide\authentication\templates\authentication\confirm_email.html:4
+#: .\authentication\templates\authentication\acc_active_email.html:3
+#: .\authentication\templates\authentication\confirm_email.html:4
 msgid "New user"
 msgstr "Nou usuari"
 
-#: .\decide\authentication\templates\authentication\acc_active_email.html:9
+#: .\authentication\templates\authentication\acc_active_email.html:9
 msgid "Thank you for your email confirmation. Now you can login your account."
 msgstr "Gràcies per la vostra confirmació per correu electrònic. Ara podeu iniciar la sessió al vostre compte."
 
-#: .\decide\authentication\templates\authentication\acc_active_email.html:11
+#: .\authentication\templates\authentication\acc_active_email.html:11
 msgid "Go to login"
 msgstr "Iniciar Sessió"
 
-#: .\decide\authentication\templates\authentication\confirm_email.html:7
+#: .\authentication\templates\authentication\confirm_email.html:7
 msgid "Please confirm your email address to complete the registration"
 msgstr "Confirmeu la vostra adreça de correu electrònic per completar el registre"
 
-#: .\decide\authentication\templates\authentication\login.html:25
+#: .\authentication\templates\authentication\login.html:25
 msgid "Log in"
 msgstr "Iniciar Sessió"
 
-#: .\decide\authentication\templates\authentication\login.html:50
+#: .\authentication\templates\authentication\login.html:50
 msgid "Login"
 msgstr "Iniciar Sessió"
 
-#: .\decide\authentication\templates\authentication\login.html:93
+#: .\authentication\templates\authentication\login.html:93
 msgid "Enter an email and a password."
 msgstr "Introduïu un correu electrònic i una contrasenya."
 
-#: .\decide\authentication\templates\authentication\login.html:105
+#: .\authentication\templates\authentication\login.html:105
 msgid "Error: The credentials are not valid"
 msgstr "Error: les credencials no són vàlides"
 
-#: .\decide\authentication\templates\authentication\login.html:108
-#: .\decide\booth\templates\booth\booth.html:312
+#: .\authentication\templates\authentication\login.html:108
+#: .\booth\templates\booth\booth.html:312
 msgid "Error: "
 msgstr "Error"
 
-#: .\decide\authentication\templates\authentication\signup.html:7
+#: .\authentication\templates\authentication\signup.html:7
 msgid "Sign up a new user"
 msgstr "Registra't un nou usuari"
 
-#: .\decide\authentication\templates\authentication\signup.html:15
+#: .\authentication\templates\authentication\signup.html:15
 msgid "Submit"
 msgstr "Presentar"
 
-#: .\decide\base\templates\base.html:125
-#: .\decide\voting\templates\voting\openVotings.html:9
-msgid "Open Votings"
-msgstr "Votatge Obert"
+#: .\base\templates\base.html:125 .\voting\templates\voting\openVotings.html:9
+msgid "Open votings"
+msgstr "Votacions obertes"
 
-#: .\decide\base\templates\base.html:165
+#: .\base\templates\base.html:166
 msgid "Footer Content"
 msgstr "Contingut del peu de pàgina"
 
-#: .\decide\base\templates\base.html:166
+#: .\base\templates\base.html:167
 msgid "Information."
 msgstr "Informació"
 
-#: .\decide\base\templates\base.html:172
+#: .\base\templates\base.html:173
 msgid "© 2018 Copyright Text"
-msgstr "© Copyright 2018 Copyright"
+msgstr "© 2018 Copyright Text"
 
-#: .\decide\base\templates\base.html:173
+#: .\base\templates\base.html:174
 msgid "More Links"
 msgstr "Més enllaços"
 
-#: .\decide\base\templates\index.html:12
+#: .\base\templates\index.html:12
 msgid "Welcome"
 msgstr "Benvinguda"
 
-#: .\decide\booth\templates\booth\booth.html:21
+#: .\booth\templates\booth\booth.html:21
 msgid "The voting can not be accessed because it has not started."
 msgstr "La votació no es pot accedir perquè no s'ha iniciat."
 
-#: .\decide\booth\templates\booth\booth.html:23
+#: .\booth\templates\booth\booth.html:23
 msgid ""
 "The voting can not be accessed because it has ended. You can access to the "
 "results in the following link: "
 msgstr "La votació no es pot accedir perquè s'ha acabat. Podeu accedir als resultats al següent enllaç:"
 
-#: .\decide\booth\templates\booth\booth.html:23
+#: .\booth\templates\booth\booth.html:23
 msgid "Results"
 msgstr "Resultats"
 
-#: .\decide\booth\templates\booth\booth.html:25
+#: .\booth\templates\booth\booth.html:25
 msgid ""
-"This vote does not contain any questions, so it can not be accessed yet. Try "
-"it again later."
+"This voting does not contain any questions, so it can not be accessed yet. "
+"Try it again later."
 msgstr "Aquesta votació no conté cap pregunta, de manera que encara no es pot accedir a ella. Proveuuna altra vegada més tard."
 
-#: .\decide\booth\templates\booth\booth.html:66
+#: .\booth\templates\booth\booth.html:66
 msgid "Answer with voice"
 msgstr "Respondre amb veu"
 
-#: .\decide\booth\templates\booth\booth.html:75
+#: .\booth\templates\booth\booth.html:75
 msgid "Send vote"
 msgstr "Enviar vot"
 
-#: .\decide\booth\templates\booth\booth.html:85
+#: .\booth\templates\booth\booth.html:85
 msgid "Speech Synthesis not supported"
 msgstr "La síntesi de veu no és compatible"
 
-#: .\decide\booth\templates\booth\booth.html:86
+#: .\booth\templates\booth\booth.html:86
 msgid "Your browser does not support speech synthesis."
 msgstr "El vostre navegador no admet la síntesi de veu."
 
-#: .\decide\booth\templates\booth\booth.html:87
+#: .\booth\templates\booth\booth.html:87
 msgid "We recommend you use Google Chrome."
 msgstr "Us recomanem que feu servir Google Chrome."
 
-#: .\decide\booth\templates\booth\booth.html:309
+#: .\booth\templates\booth\booth.html:309
 msgid "Congratulations. Your vote has been sent"
-msgstr "Felicitacions S'ha enviat el vostre vot"
+msgstr "Felicitacions. S'ha enviat el vostre vot"
 
-#: .\decide\booth\templates\booth\booth.html:317
+#: .\booth\templates\booth\booth.html:317
 msgid "You must select an option for each question."
 msgstr "Heu de seleccionar una opció per a cada pregunta."
 
-#: .\decide\visualizer\templates\visualizer\ended.html:15
-#: .\decide\visualizer\templates\visualizer\ended_export.html:6
+#: .\visualizer\templates\visualizer\ended.html:14
+#: .\visualizer\templates\visualizer\ended_export.html:7
 msgid "Results: "
 msgstr "Resultats"
 
-#: .\decide\visualizer\templates\visualizer\ended.html:152
-#: .\decide\visualizer\templates\visualizer\ongoing.html:95
+#: .\visualizer\templates\visualizer\ended.html:176
+msgid "Question:"
+msgstr "Qüestió:"
+
+#: .\visualizer\templates\visualizer\ended.html:366
+#: .\visualizer\templates\visualizer\ongoing.html:93
 msgid "Download results as .pdf"
 msgstr "Baixeu els resultats com .pdf"
 
-#: .\decide\visualizer\templates\visualizer\ended.html:154
-#: .\decide\visualizer\templates\visualizer\ongoing.html:97
+#: .\visualizer\templates\visualizer\ended.html:368
+#: .\visualizer\templates\visualizer\ongoing.html:95
 msgid "Download results as .csv"
 msgstr "Baixeu els resultats com .csv"
 
-#: .\decide\visualizer\templates\visualizer\not_started.html:16
-msgid "Voting not started"
-msgstr "No s'ha iniciat la votació"
+#: .\visualizer\templates\visualizer\ended.html:370
+#: .\visualizer\templates\visualizer\ongoing.html:97
+msgid "Download results as .json"
+msgstr "Baixeu els resultats com .json"
 
-#: .\decide\visualizer\templates\visualizer\ongoing.html:14
-msgid "In Progress"
-msgstr "En progrés"
+#: .\visualizer\templates\visualizer\list_ended.html:17
+msgid "Ended votings"
+msgstr "Votacions finalitzades"
 
-#: .\decide\visualizer\templates\visualizer\ongoing.html:21
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:6
-#: .\decide\voting\templates\voting\openVotings.html:19
-msgid "Stats"
-msgstr "Estadístiques"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:25
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:8
-msgid "Census Size:"
-msgstr "Mida del cens:"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:26
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:9
-msgid "Voters Turnout:"
-msgstr "Reconeixement de votants:"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:27
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:10
-msgid "Participation:"
-msgstr "Participació"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:42
-msgid "Interested in the participation according to genders? Check it out!"
-msgstr "Està interessat en la participació segons els sexes? Comprova-ho!"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:46
-msgid "Women"
-msgstr "Dones"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:47
-msgid "Non-Binary"
-msgstr "No binari"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:48
-msgid "Men"
-msgstr "Homes"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:51
-msgid "women voted"
-msgstr "les dones van votar"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:51
-#: .\decide\visualizer\templates\visualizer\ongoing.html:52
-#: .\decide\visualizer\templates\visualizer\ongoing.html:53
-msgid "of the total"
-msgstr "del total"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:52
-msgid "non-binary voted"
-msgstr "votació no binària"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:53
-msgid "men voted"
-msgstr "els homes van votar"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:61
-msgid "to"
-msgstr "a"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:61
-#: .\decide\visualizer\templates\visualizer\ongoing.html:74
-#: .\decide\visualizer\templates\visualizer\ongoing.html:87
-msgid "years old"
-msgstr "anys"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:70
-msgid "The average age of people who voted is..."
-msgstr "L'edat mitjana de les persones que van votar és ..."
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:76
-msgid "Nobody has voted yet :("
-msgstr "Ningú ha votat encara :("
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:83
-msgid "The average age of people who didn't vote is..."
-msgstr "L'edat mitjana de les persones que no van votar és..."
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:89
-msgid "Everyone has voted already :)"
-msgstr "Tothom ha votat ja :)"
-
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:5
-msgid "Voting is open"
-msgstr "La votació està oberta"
-
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:12
-msgid "Voter's Mean Age:"
-msgstr "Edat Mitjana de l'elector:"
-
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:15
-msgid "Non-Voter's Mean Age:"
-msgstr "Edat mitjana no votant:"
-
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:17
-msgid "Voter's Age Analysis:"
-msgstr "Anàlisi de l'edat dels votants:"
-
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:24
-msgid "Women participation:"
-msgstr "Participació de les dones:"
-
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:25
-msgid "Non-binary participation:"
-msgstr "Participació no binària:"
-
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:26
-msgid "Men participation:"
-msgstr "Participació dels homes:"
-
-#: .\decide\voting\templates\voting\openVotings.html:16
+#: .\visualizer\templates\visualizer\list_ended.html:21
+#: .\voting\templates\voting\openVotings.html:16
 msgid "Name"
 msgstr "Nom"
 
-#: .\decide\voting\templates\voting\openVotings.html:17
+#: .\visualizer\templates\visualizer\list_ended.html:22
+#: .\voting\templates\voting\openVotings.html:17
 msgid "Description"
 msgstr "Descripció"
 
-#: .\decide\voting\templates\voting\openVotings.html:18
+#: .\visualizer\templates\visualizer\list_ended.html:23
+msgid "Question(s)"
+msgstr "Preguntes"
+
+#: .\visualizer\templates\visualizer\list_ended.html:24
+msgid "Start/end"
+msgstr "Inici/final"
+
+#: .\visualizer\templates\visualizer\list_ended.html:25
+msgid "Link"
+msgstr "Enllaç"
+
+#: .\visualizer\templates\visualizer\list_ended.html:50
+msgid "Started:"
+msgstr "Iniciat:"
+
+#: .\visualizer\templates\visualizer\list_ended.html:51
+msgid "Ended:"
+msgstr "Finalitzada:"
+
+#: .\visualizer\templates\visualizer\list_ended.html:55
+msgid "Go"
+msgstr "Anar"
+
+#: .\visualizer\templates\visualizer\list_ended.html:61
+msgid "There are no ended votings yet"
+msgstr "Encara no hi ha cap votació finalitzada"
+
+#: .\visualizer\templates\visualizer\not_started.html:13
+msgid "Voting not started"
+msgstr "No s'ha iniciat la votació"
+
+#: .\visualizer\templates\visualizer\not_tally.html:12
+msgid "Votes have not been counted yet. Please try again later"
+msgstr "Encara no s'han comptabilitzat els vots. Siusplau, intenta-ho més tard"
+
+#: .\visualizer\templates\visualizer\ongoing.html:12
+msgid "In Progress"
+msgstr "En progrés"
+
+#: .\visualizer\templates\visualizer\ongoing.html:19
+#: .\visualizer\templates\visualizer\ongoing_export.html:6
+#: .\voting\templates\voting\openVotings.html:19
+msgid "Stats"
+msgstr "Estadístiques"
+
+#: .\visualizer\templates\visualizer\ongoing.html:23
+#: .\visualizer\templates\visualizer\ongoing_export.html:8
+msgid "Census Size:"
+msgstr "Mida del cens:"
+
+#: .\visualizer\templates\visualizer\ongoing.html:24
+#: .\visualizer\templates\visualizer\ongoing_export.html:9
+msgid "Voters Turnout:"
+msgstr "Reconeixement de votants:"
+
+#: .\visualizer\templates\visualizer\ongoing.html:25
+#: .\visualizer\templates\visualizer\ongoing_export.html:10
+msgid "Participation:"
+msgstr "Participació"
+
+#: .\visualizer\templates\visualizer\ongoing.html:40
+msgid "Interested in the participation according to genders? Check it out!"
+msgstr "Està interessat en la participació segons els sexes? Comprova-ho!"
+
+#: .\visualizer\templates\visualizer\ongoing.html:44
+msgid "Women"
+msgstr "Dones"
+
+#: .\visualizer\templates\visualizer\ongoing.html:45
+msgid "Non-Binary"
+msgstr "No binari"
+
+#: .\visualizer\templates\visualizer\ongoing.html:46
+msgid "Men"
+msgstr "Homes"
+
+#: .\visualizer\templates\visualizer\ongoing.html:49
+msgid "women voted"
+msgstr "les dones van votar"
+
+#: .\visualizer\templates\visualizer\ongoing.html:49
+#: .\visualizer\templates\visualizer\ongoing.html:50
+#: .\visualizer\templates\visualizer\ongoing.html:51
+msgid "of the total"
+msgstr "del total"
+
+#: .\visualizer\templates\visualizer\ongoing.html:50
+msgid "non-binary voted"
+msgstr "votació no binària"
+
+#: .\visualizer\templates\visualizer\ongoing.html:51
+msgid "men voted"
+msgstr "els homes van votar"
+
+#: .\visualizer\templates\visualizer\ongoing.html:59
+msgid "to"
+msgstr "a"
+
+#: .\visualizer\templates\visualizer\ongoing.html:59
+#: .\visualizer\templates\visualizer\ongoing.html:72
+#: .\visualizer\templates\visualizer\ongoing.html:85
+msgid "years old"
+msgstr "anys"
+
+#: .\visualizer\templates\visualizer\ongoing.html:68
+msgid "The average age of people who voted is..."
+msgstr "L'edat mitjana de les persones que van votar és ..."
+
+#: .\visualizer\templates\visualizer\ongoing.html:74
+msgid "Nobody has voted yet :("
+msgstr "Ningú ha votat encara :("
+
+#: .\visualizer\templates\visualizer\ongoing.html:81
+msgid "The average age of people who didn't vote is..."
+msgstr "L'edat mitjana de les persones que no van votar és..."
+
+#: .\visualizer\templates\visualizer\ongoing.html:87
+msgid "Everyone has voted already :)"
+msgstr "Tothom ha votat ja :)"
+
+#: .\visualizer\templates\visualizer\ongoing_export.html:5
+msgid "Voting is open"
+msgstr "La votació està oberta"
+
+#: .\visualizer\templates\visualizer\ongoing_export.html:12
+msgid "Voter's Mean Age:"
+msgstr "Edat Mitjana de l'elector:"
+
+#: .\visualizer\templates\visualizer\ongoing_export.html:15
+msgid "Non-Voter's Mean Age:"
+msgstr "Edat mitjana no votant:"
+
+#: .\visualizer\templates\visualizer\ongoing_export.html:17
+msgid "Voter's Age Analysis:"
+msgstr "Anàlisi de l'edat dels votants:"
+
+#: .\visualizer\templates\visualizer\ongoing_export.html:24
+msgid "Women participation:"
+msgstr "Participació de les dones:"
+
+#: .\visualizer\templates\visualizer\ongoing_export.html:25
+msgid "Non-binary participation:"
+msgstr "Participació no binària:"
+
+#: .\visualizer\templates\visualizer\ongoing_export.html:26
+msgid "Men participation:"
+msgstr "Participació dels homes:"
+
+#: .\voting\templates\voting\openVotings.html:18
 msgid "Booth"
 msgstr "Cabina"
 
-#: .\decide\voting\templates\voting\openVotings.html:30
+#: .\voting\templates\voting\openVotings.html:30
 msgid "Not provided."
 msgstr "No proporcionat."
 
-#: .\decide\voting\templates\voting\openVotings.html:33
+#: .\voting\templates\voting\openVotings.html:33
 msgid "Access to the booth"
-msgstr "Accés a l'estand"
+msgstr "Accedir a la cabina"
 
-#: .\decide\voting\templates\voting\openVotings.html:34
+#: .\voting\templates\voting\openVotings.html:34
 msgid "See the stats"
 msgstr "Veure les estadístiques"
 
-#: .\decide\voting\templates\voting\openVotings.html:42
+#: .\voting\templates\voting\openVotings.html:42
 msgid "There are no open votings in the system."
 msgstr "No hi ha votacions obertes al sistema."
 

--- a/decide/locale/ca/LC_MESSAGES/django.po
+++ b/decide/locale/ca/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-08 10:00+0000\n"
+"POT-Creation-Date: 2019-01-09 19:00+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,346 +17,372 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
-#: authentication/forms.py:13
+#: .\decide\authentication\forms.py:13
 msgid "Man"
 msgstr "Homes"
 
-#: authentication/forms.py:14
+#: .\decide\authentication\forms.py:14
 msgid "Woman"
 msgstr "dona"
 
-#: authentication/forms.py:15
+#: .\decide\authentication\forms.py:15
 msgid "Non-binary"
 msgstr "No binari"
 
-#: authentication/forms.py:17
+#: .\decide\authentication\forms.py:17
 msgid "Format: dd/mm/YYYY"
 msgstr "Format: dd/mm/AAAA"
 
-#: authentication/forms.py:19 authentication/models.py:17
+#: .\decide\authentication\forms.py:19 .\decide\authentication\models.py:17
 msgid "First name"
 msgstr "Nom"
 
-#: authentication/forms.py:20 authentication/models.py:18
+#: .\decide\authentication\forms.py:20 .\decide\authentication\models.py:18
 msgid "Last name"
 msgstr "Cognom"
 
-#: authentication/forms.py:21 authentication/models.py:16
-#: authentication/serializers.py:16
-#: authentication/templates/authentication/login.html:37
+#: .\decide\authentication\forms.py:21 .\decide\authentication\models.py:16
+#: .\decide\authentication\serializers.py:16
+#: .\decide\authentication\templates\authentication\login.html:37
 msgid "Email"
 msgstr "Correu electrònic"
 
-#: authentication/forms.py:22 authentication/models.py:19
+#: .\decide\authentication\forms.py:22 .\decide\authentication\models.py:19
 msgid "Birthdate"
 msgstr "Data de naixement"
 
-#: authentication/forms.py:23 authentication/models.py:20
+#: .\decide\authentication\forms.py:23 .\decide\authentication\models.py:20
 msgid "City"
 msgstr "Ciutat"
 
-#: authentication/forms.py:24 authentication/models.py:21
+#: .\decide\authentication\forms.py:24 .\decide\authentication\models.py:21
 msgid "Sex"
 msgstr "Sexe"
 
-#: authentication/forms.py:54
+#: .\decide\authentication\forms.py:54
 msgid "Email alredy exits"
 msgstr "Correu electrònic de sortida"
 
-#: authentication/forms.py:64
+#: .\decide\authentication\forms.py:64
 msgid "Future date not posible"
 msgstr "La data futura no és possible"
 
-#: authentication/models.py:22
+#: .\decide\authentication\models.py:22
 msgid "Is active"
 msgstr "Està actiu"
 
-#: authentication/models.py:23
+#: .\decide\authentication\models.py:23
 msgid "Is staf"
 msgstr "És staf"
 
-#: authentication/schemas/inspectors.py:114
+#: .\decide\authentication\schemas\inspectors.py:114
 msgid "unique integer value"
 msgstr "unique integer value"
 
-#: authentication/schemas/inspectors.py:116
+#: .\decide\authentication\schemas\inspectors.py:116
 msgid "UUID string"
 msgstr "UUID string"
 
-#: authentication/schemas/inspectors.py:118
+#: .\decide\authentication\schemas\inspectors.py:118
 msgid "unique value"
 msgstr "unique value"
 
-#: authentication/schemas/inspectors.py:120
+#: .\decide\authentication\schemas\inspectors.py:120
 #, python-brace-format
 msgid "A {value_type} identifying this {name}."
 msgstr "A {value_type} identifying this {name}."
 
-#: authentication/serializers.py:18
-#: authentication/templates/authentication/login.html:45
+#: .\decide\authentication\serializers.py:18
+#: .\decide\authentication\templates\authentication\login.html:45
 msgid "Password"
 msgstr "Contrasenya"
 
-#: authentication/serializers.py:32
+#: .\decide\authentication\serializers.py:32
 msgid "Unable to log in with provided credentials."
 msgstr "No es pot iniciar sessió amb les credencials proporcionades."
 
-#: authentication/serializers.py:35
+#: .\decide\authentication\serializers.py:35
 msgid "Must include \"email\" and \"password\"."
 msgstr "Ha d'incloure \"correu electrònic\" i \"contrasenya\"."
 
-#: authentication/templates/authentication/acc_active_email.html:3
-#: authentication/templates/authentication/confirm_email.html:4
+#: .\decide\authentication\templates\authentication\acc_active_email.html:3
+#: .\decide\authentication\templates\authentication\confirm_email.html:4
 msgid "New user"
 msgstr "Nou usuari"
 
-#: authentication/templates/authentication/acc_active_email.html:9
+#: .\decide\authentication\templates\authentication\acc_active_email.html:9
 msgid "Thank you for your email confirmation. Now you can login your account."
-msgstr ""
-"Gràcies per la vostra confirmació per correu electrònic. Ara podeu iniciar "
-"la sessió al vostre compte."
+msgstr "Gràcies per la vostra confirmació per correu electrònic. Ara podeu iniciar la sessió al vostre compte."
 
-#: authentication/templates/authentication/acc_active_email.html:11
+#: .\decide\authentication\templates\authentication\acc_active_email.html:11
 msgid "Go to login"
 msgstr "Iniciar Sessió"
 
-#: authentication/templates/authentication/confirm_email.html:7
+#: .\decide\authentication\templates\authentication\confirm_email.html:7
 msgid "Please confirm your email address to complete the registration"
-msgstr ""
-"Confirmeu la vostra adreça de correu electrònic per completar el registre"
+msgstr "Confirmeu la vostra adreça de correu electrònic per completar el registre"
 
-#: authentication/templates/authentication/login.html:25
+#: .\decide\authentication\templates\authentication\login.html:25
 msgid "Log in"
 msgstr "Iniciar Sessió"
 
-#: authentication/templates/authentication/login.html:50
+#: .\decide\authentication\templates\authentication\login.html:50
 msgid "Login"
 msgstr "Iniciar Sessió"
 
-#: authentication/templates/authentication/login.html:93
+#: .\decide\authentication\templates\authentication\login.html:93
 msgid "Enter an email and a password."
 msgstr "Introduïu un correu electrònic i una contrasenya."
 
-#: authentication/templates/authentication/login.html:105
+#: .\decide\authentication\templates\authentication\login.html:105
 msgid "Error: The credentials are not valid"
 msgstr "Error: les credencials no són vàlides"
 
-#: authentication/templates/authentication/login.html:108
-#: booth/templates/booth/booth.html:312
+#: .\decide\authentication\templates\authentication\login.html:108
+#: .\decide\booth\templates\booth\booth.html:312
 msgid "Error: "
-msgstr "Error:"
+msgstr "Error"
 
-#: authentication/templates/authentication/signup.html:7
+#: .\decide\authentication\templates\authentication\signup.html:7
 msgid "Sign up a new user"
 msgstr "Registra't un nou usuari"
 
-#: authentication/templates/authentication/signup.html:15
+#: .\decide\authentication\templates\authentication\signup.html:15
 msgid "Submit"
 msgstr "Presentar"
 
-#: base/templates/base.html:165
+#: .\decide\base\templates\base.html:125
+#: .\decide\voting\templates\voting\openVotings.html:9
+msgid "Open Votings"
+msgstr "Votatge Obert"
+
+#: .\decide\base\templates\base.html:165
 msgid "Footer Content"
 msgstr "Contingut del peu de pàgina"
 
-#: base/templates/base.html:166
+#: .\decide\base\templates\base.html:166
 msgid "Information."
-msgstr "Informació."
+msgstr "Informació"
 
-#: base/templates/base.html:172
+#: .\decide\base\templates\base.html:172
 msgid "© 2018 Copyright Text"
-msgstr "© 2018 Copyright Text"
+msgstr "© Copyright 2018 Copyright"
 
-#: base/templates/base.html:173
+#: .\decide\base\templates\base.html:173
 msgid "More Links"
 msgstr "Més enllaços"
 
-#: base/templates/index.html:12
+#: .\decide\base\templates\index.html:12
 msgid "Welcome"
 msgstr "Benvinguda"
 
-#: booth/templates/booth/booth.html:21
+#: .\decide\booth\templates\booth\booth.html:21
 msgid "The voting can not be accessed because it has not started."
 msgstr "La votació no es pot accedir perquè no s'ha iniciat."
 
-#: booth/templates/booth/booth.html:23
+#: .\decide\booth\templates\booth\booth.html:23
 msgid ""
 "The voting can not be accessed because it has ended. You can access to the "
 "results in the following link: "
-msgstr ""
-"La votació no es pot accedir perquè s'ha acabat. Podeu accedir al es mostra "
-"en el següent enllaç:"
+msgstr "La votació no es pot accedir perquè s'ha acabat. Podeu accedir als resultats al següent enllaç:"
 
-#: booth/templates/booth/booth.html:23
+#: .\decide\booth\templates\booth\booth.html:23
 msgid "Results"
 msgstr "Resultats"
 
-#: booth/templates/booth/booth.html:25
+#: .\decide\booth\templates\booth\booth.html:25
 msgid ""
 "This vote does not contain any questions, so it can not be accessed yet. Try "
 "it again later."
-msgstr ""
-"Aquesta votació no conté cap pregunta, de manera que encara no es pot "
-"accedir a ella. Proveuuna altra vegada més tard."
+msgstr "Aquesta votació no conté cap pregunta, de manera que encara no es pot accedir a ella. Proveuuna altra vegada més tard."
 
-#: booth/templates/booth/booth.html:66
+#: .\decide\booth\templates\booth\booth.html:66
 msgid "Answer with voice"
 msgstr "Respondre amb veu"
 
-#: booth/templates/booth/booth.html:75
+#: .\decide\booth\templates\booth\booth.html:75
 msgid "Send vote"
 msgstr "Enviar vot"
 
-#: booth/templates/booth/booth.html:85
+#: .\decide\booth\templates\booth\booth.html:85
 msgid "Speech Synthesis not supported"
 msgstr "La síntesi de veu no és compatible"
 
-#: booth/templates/booth/booth.html:86
+#: .\decide\booth\templates\booth\booth.html:86
 msgid "Your browser does not support speech synthesis."
 msgstr "El vostre navegador no admet la síntesi de veu."
 
-#: booth/templates/booth/booth.html:87
+#: .\decide\booth\templates\booth\booth.html:87
 msgid "We recommend you use Google Chrome."
 msgstr "Us recomanem que feu servir Google Chrome."
 
-#: booth/templates/booth/booth.html:309
+#: .\decide\booth\templates\booth\booth.html:309
 msgid "Congratulations. Your vote has been sent"
 msgstr "Felicitacions S'ha enviat el vostre vot"
 
-#: booth/templates/booth/booth.html:317
+#: .\decide\booth\templates\booth\booth.html:317
 msgid "You must select an option for each question."
 msgstr "Heu de seleccionar una opció per a cada pregunta."
 
-#: visualizer/templates/visualizer/ended.html:15
-#: visualizer/templates/visualizer/ended_export.html:6
+#: .\decide\visualizer\templates\visualizer\ended.html:15
+#: .\decide\visualizer\templates\visualizer\ended_export.html:6
 msgid "Results: "
-msgstr "Resultats:"
+msgstr "Resultats"
 
-#: visualizer/templates/visualizer/ended.html:152
-#: visualizer/templates/visualizer/ongoing.html:95
+#: .\decide\visualizer\templates\visualizer\ended.html:152
+#: .\decide\visualizer\templates\visualizer\ongoing.html:95
 msgid "Download results as .pdf"
 msgstr "Baixeu els resultats com .pdf"
 
-#: visualizer/templates/visualizer/ended.html:154
-#: visualizer/templates/visualizer/ongoing.html:97
+#: .\decide\visualizer\templates\visualizer\ended.html:154
+#: .\decide\visualizer\templates\visualizer\ongoing.html:97
 msgid "Download results as .csv"
 msgstr "Baixeu els resultats com .csv"
 
-#: visualizer/templates/visualizer/not_started.html:16
+#: .\decide\visualizer\templates\visualizer\not_started.html:16
 msgid "Voting not started"
 msgstr "No s'ha iniciat la votació"
 
-#: visualizer/templates/visualizer/ongoing.html:14
+#: .\decide\visualizer\templates\visualizer\ongoing.html:14
 msgid "In Progress"
 msgstr "En progrés"
 
-#: visualizer/templates/visualizer/ongoing.html:21
-#: visualizer/templates/visualizer/ongoing_export.html:6
+#: .\decide\visualizer\templates\visualizer\ongoing.html:21
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:6
+#: .\decide\voting\templates\voting\openVotings.html:19
 msgid "Stats"
 msgstr "Estadístiques"
 
-#: visualizer/templates/visualizer/ongoing.html:25
-#: visualizer/templates/visualizer/ongoing_export.html:8
+#: .\decide\visualizer\templates\visualizer\ongoing.html:25
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:8
 msgid "Census Size:"
 msgstr "Mida del cens:"
 
-#: visualizer/templates/visualizer/ongoing.html:26
-#: visualizer/templates/visualizer/ongoing_export.html:9
+#: .\decide\visualizer\templates\visualizer\ongoing.html:26
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:9
 msgid "Voters Turnout:"
 msgstr "Reconeixement de votants:"
 
-#: visualizer/templates/visualizer/ongoing.html:27
-#: visualizer/templates/visualizer/ongoing_export.html:10
+#: .\decide\visualizer\templates\visualizer\ongoing.html:27
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:10
 msgid "Participation:"
-msgstr "Participació:"
+msgstr "Participació"
 
-#: visualizer/templates/visualizer/ongoing.html:42
+#: .\decide\visualizer\templates\visualizer\ongoing.html:42
 msgid "Interested in the participation according to genders? Check it out!"
 msgstr "Està interessat en la participació segons els sexes? Comprova-ho!"
 
-#: visualizer/templates/visualizer/ongoing.html:46
+#: .\decide\visualizer\templates\visualizer\ongoing.html:46
 msgid "Women"
 msgstr "Dones"
 
-#: visualizer/templates/visualizer/ongoing.html:47
+#: .\decide\visualizer\templates\visualizer\ongoing.html:47
 msgid "Non-Binary"
 msgstr "No binari"
 
-#: visualizer/templates/visualizer/ongoing.html:48
+#: .\decide\visualizer\templates\visualizer\ongoing.html:48
 msgid "Men"
 msgstr "Homes"
 
-#: visualizer/templates/visualizer/ongoing.html:51
+#: .\decide\visualizer\templates\visualizer\ongoing.html:51
 msgid "women voted"
 msgstr "les dones van votar"
 
-#: visualizer/templates/visualizer/ongoing.html:51
-#: visualizer/templates/visualizer/ongoing.html:52
-#: visualizer/templates/visualizer/ongoing.html:53
+#: .\decide\visualizer\templates\visualizer\ongoing.html:51
+#: .\decide\visualizer\templates\visualizer\ongoing.html:52
+#: .\decide\visualizer\templates\visualizer\ongoing.html:53
 msgid "of the total"
 msgstr "del total"
 
-#: visualizer/templates/visualizer/ongoing.html:52
+#: .\decide\visualizer\templates\visualizer\ongoing.html:52
 msgid "non-binary voted"
 msgstr "votació no binària"
 
-#: visualizer/templates/visualizer/ongoing.html:53
+#: .\decide\visualizer\templates\visualizer\ongoing.html:53
 msgid "men voted"
 msgstr "els homes van votar"
 
-#: visualizer/templates/visualizer/ongoing.html:61
+#: .\decide\visualizer\templates\visualizer\ongoing.html:61
 msgid "to"
 msgstr "a"
 
-#: visualizer/templates/visualizer/ongoing.html:61
-#: visualizer/templates/visualizer/ongoing.html:74
-#: visualizer/templates/visualizer/ongoing.html:87
+#: .\decide\visualizer\templates\visualizer\ongoing.html:61
+#: .\decide\visualizer\templates\visualizer\ongoing.html:74
+#: .\decide\visualizer\templates\visualizer\ongoing.html:87
 msgid "years old"
 msgstr "anys"
 
-#: visualizer/templates/visualizer/ongoing.html:70
+#: .\decide\visualizer\templates\visualizer\ongoing.html:70
 msgid "The average age of people who voted is..."
 msgstr "L'edat mitjana de les persones que van votar és ..."
 
-#: visualizer/templates/visualizer/ongoing.html:76
+#: .\decide\visualizer\templates\visualizer\ongoing.html:76
 msgid "Nobody has voted yet :("
 msgstr "Ningú ha votat encara :("
 
-#: visualizer/templates/visualizer/ongoing.html:83
+#: .\decide\visualizer\templates\visualizer\ongoing.html:83
 msgid "The average age of people who didn't vote is..."
 msgstr "L'edat mitjana de les persones que no van votar és..."
 
-#: visualizer/templates/visualizer/ongoing.html:89
+#: .\decide\visualizer\templates\visualizer\ongoing.html:89
 msgid "Everyone has voted already :)"
 msgstr "Tothom ha votat ja :)"
 
-#: visualizer/templates/visualizer/ongoing_export.html:5
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:5
 msgid "Voting is open"
 msgstr "La votació està oberta"
 
-#: visualizer/templates/visualizer/ongoing_export.html:12
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:12
 msgid "Voter's Mean Age:"
 msgstr "Edat Mitjana de l'elector:"
 
-#: visualizer/templates/visualizer/ongoing_export.html:15
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:15
 msgid "Non-Voter's Mean Age:"
 msgstr "Edat mitjana no votant:"
 
-#: visualizer/templates/visualizer/ongoing_export.html:17
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:17
 msgid "Voter's Age Analysis:"
 msgstr "Anàlisi de l'edat dels votants:"
 
-#: visualizer/templates/visualizer/ongoing_export.html:24
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:24
 msgid "Women participation:"
 msgstr "Participació de les dones:"
 
-#: visualizer/templates/visualizer/ongoing_export.html:25
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:25
 msgid "Non-binary participation:"
 msgstr "Participació no binària:"
 
-#: visualizer/templates/visualizer/ongoing_export.html:26
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:26
 msgid "Men participation:"
 msgstr "Participació dels homes:"
+
+#: .\decide\voting\templates\voting\openVotings.html:16
+msgid "Name"
+msgstr "Nom"
+
+#: .\decide\voting\templates\voting\openVotings.html:17
+msgid "Description"
+msgstr "Descripció"
+
+#: .\decide\voting\templates\voting\openVotings.html:18
+msgid "Booth"
+msgstr "Cabina"
+
+#: .\decide\voting\templates\voting\openVotings.html:30
+msgid "Not provided."
+msgstr "No proporcionat."
+
+#: .\decide\voting\templates\voting\openVotings.html:33
+msgid "Access to the booth"
+msgstr "Accés a l'estand"
+
+#: .\decide\voting\templates\voting\openVotings.html:34
+msgid "See the stats"
+msgstr "Veure les estadístiques"
+
+#: .\decide\voting\templates\voting\openVotings.html:42
+msgid "There are no open votings in the system."
+msgstr "No hi ha votacions obertes al sistema."
 
 #: .\decide\settings.py:148
 msgid "English"

--- a/decide/locale/es/LC_MESSAGES/django.po
+++ b/decide/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-09 19:00+0100\n"
+"POT-Creation-Date: 2019-01-10 11:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,370 +17,417 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-#: .\decide\authentication\forms.py:13
+
+#: .\authentication\forms.py:13
 msgid "Man"
 msgstr "Hombre"
 
-#: .\decide\authentication\forms.py:14
+#: .\authentication\forms.py:14
 msgid "Woman"
 msgstr "Mujer"
 
-#: .\decide\authentication\forms.py:15
+#: .\authentication\forms.py:15
 msgid "Non-binary"
 msgstr "No binario"
 
-#: .\decide\authentication\forms.py:17
+#: .\authentication\forms.py:17
 msgid "Format: dd/mm/YYYY"
 msgstr "Formato: dd/mm/YYYY"
 
-#: .\decide\authentication\forms.py:19 .\decide\authentication\models.py:17
+#: .\authentication\forms.py:19 .\authentication\models.py:17
 msgid "First name"
 msgstr "Nombre"
 
-#: .\decide\authentication\forms.py:20 .\decide\authentication\models.py:18
+#: .\authentication\forms.py:20 .\authentication\models.py:18
 msgid "Last name"
 msgstr "Apellidos"
 
-#: .\decide\authentication\forms.py:21 .\decide\authentication\models.py:16
-#: .\decide\authentication\serializers.py:16
-#: .\decide\authentication\templates\authentication\login.html:37
+#: .\authentication\forms.py:21 .\authentication\models.py:16
+#: .\authentication\serializers.py:16
+#: .\authentication\templates\authentication\login.html:37
 msgid "Email"
 msgstr "Correo electrónico"
 
-#: .\decide\authentication\forms.py:22 .\decide\authentication\models.py:19
+#: .\authentication\forms.py:22 .\authentication\models.py:19
 msgid "Birthdate"
 msgstr "Fecha de nacimiento"
 
-#: .\decide\authentication\forms.py:23 .\decide\authentication\models.py:20
+#: .\authentication\forms.py:23 .\authentication\models.py:20
 msgid "City"
 msgstr "Ciudad"
 
-#: .\decide\authentication\forms.py:24 .\decide\authentication\models.py:21
+#: .\authentication\forms.py:24 .\authentication\models.py:21
 msgid "Sex"
 msgstr "Sexo"
 
-#: .\decide\authentication\forms.py:54
+#: .\authentication\forms.py:54
 msgid "Email alredy exits"
 msgstr "El correo electrónico ya existe"
 
-#: .\decide\authentication\forms.py:64
+#: .\authentication\forms.py:64
 msgid "Future date not posible"
 msgstr "Fechas posteriores no validas"
 
-#: .\decide\authentication\models.py:22
+#: .\authentication\models.py:22
 msgid "Is active"
 msgstr "Está activo"
 
-#: .\decide\authentication\models.py:23
+#: .\authentication\models.py:23
 msgid "Is staf"
 msgstr "Es personal autorizado"
 
-#: .\decide\authentication\schemas\inspectors.py:114
+#: .\authentication\schemas\inspectors.py:114
 msgid "unique integer value"
 msgstr "unique integer value"
 
-#: .\decide\authentication\schemas\inspectors.py:116
+#: .\authentication\schemas\inspectors.py:116
 msgid "UUID string"
 msgstr "UUID string"
 
-#: .\decide\authentication\schemas\inspectors.py:118
+#: .\authentication\schemas\inspectors.py:118
 msgid "unique value"
 msgstr "unique value"
 
-#: .\decide\authentication\schemas\inspectors.py:120
+#: .\authentication\schemas\inspectors.py:120
 #, python-brace-format
 msgid "A {value_type} identifying this {name}."
 msgstr "A {value_type} identifying this {name}."
 
-#: .\decide\authentication\serializers.py:18
-#: .\decide\authentication\templates\authentication\login.html:45
+#: .\authentication\serializers.py:18
+#: .\authentication\templates\authentication\login.html:45
 msgid "Password"
 msgstr "Contraseña"
 
-#: .\decide\authentication\serializers.py:32
+#: .\authentication\serializers.py:32
 msgid "Unable to log in with provided credentials."
 msgstr "No se puede iniciar sesión con las credenciales provistas."
 
-#: .\decide\authentication\serializers.py:35
+#: .\authentication\serializers.py:35
 msgid "Must include \"email\" and \"password\"."
 msgstr "Debe incluir \"email\" and \"contraseña\"."
 
-#: .\decide\authentication\templates\authentication\acc_active_email.html:3
-#: .\decide\authentication\templates\authentication\confirm_email.html:4
+#: .\authentication\templates\authentication\acc_active_email.html:3
+#: .\authentication\templates\authentication\confirm_email.html:4
 msgid "New user"
 msgstr "Nuev@ usuari@"
 
-#: .\decide\authentication\templates\authentication\acc_active_email.html:9
+#: .\authentication\templates\authentication\acc_active_email.html:9
 msgid "Thank you for your email confirmation. Now you can login your account."
 msgstr "Gracias por la confirmación del correo electrónico. Ahora puedes iniciar la sesión de tu cuenta."
 
-#: .\decide\authentication\templates\authentication\acc_active_email.html:11
+#: .\authentication\templates\authentication\acc_active_email.html:11
 msgid "Go to login"
 msgstr "Iniciar Sesión"
 
-#: .\decide\authentication\templates\authentication\confirm_email.html:7
+#: .\authentication\templates\authentication\confirm_email.html:7
 msgid "Please confirm your email address to complete the registration"
 msgstr "Por favor, confirme su dirección de correo electrónico para completar el registro"
 
-#: .\decide\authentication\templates\authentication\login.html:25
+#: .\authentication\templates\authentication\login.html:25
 msgid "Log in"
 msgstr "Iniciar Sesión"
 
-#: .\decide\authentication\templates\authentication\login.html:50
+#: .\authentication\templates\authentication\login.html:50
 msgid "Login"
 msgstr "Iniciar Sesión"
 
-#: .\decide\authentication\templates\authentication\login.html:93
+#: .\authentication\templates\authentication\login.html:93
 msgid "Enter an email and a password."
 msgstr "Introduzca un correo electrónico y una contraseña."
 
-#: .\decide\authentication\templates\authentication\login.html:105
+#: .\authentication\templates\authentication\login.html:105
 msgid "Error: The credentials are not valid"
 msgstr "Error: Las credenciales no son válidas"
 
-#: .\decide\authentication\templates\authentication\login.html:108
-#: .\decide\booth\templates\booth\booth.html:312
+#: .\authentication\templates\authentication\login.html:108
+#: .\booth\templates\booth\booth.html:312
 msgid "Error: "
 msgstr "Error"
 
-#: .\decide\authentication\templates\authentication\signup.html:7
+#: .\authentication\templates\authentication\signup.html:7
 msgid "Sign up a new user"
 msgstr "Registrar nuev@ usuari@"
 
-#: .\decide\authentication\templates\authentication\signup.html:15
+#: .\authentication\templates\authentication\signup.html:15
 msgid "Submit"
 msgstr "Enviar"
 
-#: .\decide\base\templates\base.html:125
-#: .\decide\voting\templates\voting\openVotings.html:9
-msgid "Open Votings"
-msgstr "Votaciones Abiertas"
+#: .\base\templates\base.html:125 .\voting\templates\voting\openVotings.html:9
+msgid "Open votings"
+msgstr "Votaciones abiertas"
 
-#: .\decide\base\templates\base.html:165
+#: .\base\templates\base.html:166
 msgid "Footer Content"
 msgstr "Contenido de pie de página"
 
-#: .\decide\base\templates\base.html:166
+#: .\base\templates\base.html:167
 msgid "Information."
 msgstr "Información."
 
-#: .\decide\base\templates\base.html:172
+#: .\base\templates\base.html:173
 msgid "© 2018 Copyright Text"
 msgstr "© 2018 Copyright Text"
 
-#: .\decide\base\templates\base.html:173
+#: .\base\templates\base.html:174
 msgid "More Links"
 msgstr "Más enlaces"
 
-#: .\decide\base\templates\index.html:12
+#: .\base\templates\index.html:12
 msgid "Welcome"
 msgstr "Bienvenid@"
 
-#: .\decide\booth\templates\booth\booth.html:21
+#: .\booth\templates\booth\booth.html:21
 msgid "The voting can not be accessed because it has not started."
 msgstr "No se puede acceder a la votación porque no ha comenzado."
 
-#: .\decide\booth\templates\booth\booth.html:23
+#: .\booth\templates\booth\booth.html:23
 msgid ""
 "The voting can not be accessed because it has ended. You can access to the "
 "results in the following link: "
 msgstr "No se puede acceder a la votación porque ya ha terminado. Puedes acceder al resultado en el siguiente link:"
 
-#: .\decide\booth\templates\booth\booth.html:23
+#: .\booth\templates\booth\booth.html:23
 msgid "Results"
 msgstr "Resultados"
 
-#: .\decide\booth\templates\booth\booth.html:25
+#: .\booth\templates\booth\booth.html:25
 msgid ""
-"This vote does not contain any questions, so it can not be accessed yet. Try "
-"it again later."
+"This voting does not contain any questions, so it can not be accessed yet. "
+"Try it again later."
 msgstr "Esta votación no contiene preguntas, por lo que aún no se puede acceder. Inténtalo de nuevo más tarde."
 
-#: .\decide\booth\templates\booth\booth.html:66
+#: .\booth\templates\booth\booth.html:66
 msgid "Answer with voice"
 msgstr "Responder con voz"
 
-#: .\decide\booth\templates\booth\booth.html:75
+#: .\booth\templates\booth\booth.html:75
 msgid "Send vote"
 msgstr "Enviar voto"
 
-#: .\decide\booth\templates\booth\booth.html:85
+#: .\booth\templates\booth\booth.html:85
 msgid "Speech Synthesis not supported"
 msgstr "Síntesis de voz no soportada"
 
-#: .\decide\booth\templates\booth\booth.html:86
+#: .\booth\templates\booth\booth.html:86
 msgid "Your browser does not support speech synthesis."
 msgstr "Su navegador no soporta la síntesis de voz."
 
-#: .\decide\booth\templates\booth\booth.html:87
+#: .\booth\templates\booth\booth.html:87
 msgid "We recommend you use Google Chrome."
 msgstr "Le recomendamos utilizar Google Chrome."
 
-#: .\decide\booth\templates\booth\booth.html:309
+#: .\booth\templates\booth\booth.html:309
 msgid "Congratulations. Your vote has been sent"
 msgstr "Felicidades. Tu voto ha sido enviado."
 
-#: .\decide\booth\templates\booth\booth.html:317
+#: .\booth\templates\booth\booth.html:317
 msgid "You must select an option for each question."
 msgstr "Debes seleccionar una opción para cada pregunta."
 
-#: .\decide\visualizer\templates\visualizer\ended.html:15
-#: .\decide\visualizer\templates\visualizer\ended_export.html:6
+#: .\visualizer\templates\visualizer\ended.html:14
+#: .\visualizer\templates\visualizer\ended_export.html:7
 msgid "Results: "
 msgstr "Resultados"
 
-#: .\decide\visualizer\templates\visualizer\ended.html:152
-#: .\decide\visualizer\templates\visualizer\ongoing.html:95
+#: .\visualizer\templates\visualizer\ended.html:176
+msgid "Question:"
+msgstr "Pregunta:"
+
+#: .\visualizer\templates\visualizer\ended.html:366
+#: .\visualizer\templates\visualizer\ongoing.html:93
 msgid "Download results as .pdf"
 msgstr "Descargar los resultados en formato .pdf"
 
-#: .\decide\visualizer\templates\visualizer\ended.html:154
-#: .\decide\visualizer\templates\visualizer\ongoing.html:97
+#: .\visualizer\templates\visualizer\ended.html:368
+#: .\visualizer\templates\visualizer\ongoing.html:95
 msgid "Download results as .csv"
 msgstr "Descargar los resultados en formato .csv"
 
-#: .\decide\visualizer\templates\visualizer\not_started.html:16
-msgid "Voting not started"
-msgstr "La votación no ha comenzado"
+#: .\visualizer\templates\visualizer\ended.html:370
+#: .\visualizer\templates\visualizer\ongoing.html:97
+msgid "Download results as .json"
+msgstr "Descargar los resultados en formato .json"
 
-#: .\decide\visualizer\templates\visualizer\ongoing.html:14
-msgid "In Progress"
-msgstr "En progreso"
+#: .\visualizer\templates\visualizer\list_ended.html:17
+msgid "Ended votings"
+msgstr "Votaciones terminadas"
 
-#: .\decide\visualizer\templates\visualizer\ongoing.html:21
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:6
-#: .\decide\voting\templates\voting\openVotings.html:19
-msgid "Stats"
-msgstr "Estadisticas"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:25
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:8
-msgid "Census Size:"
-msgstr "Tamaño del censo"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:26
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:9
-msgid "Voters Turnout:"
-msgstr "Asistencia de los votantes"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:27
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:10
-msgid "Participation:"
-msgstr "Participación"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:42
-msgid "Interested in the participation according to genders? Check it out!"
-msgstr "¿Quieres saber la participación por género? ¡Míralo!"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:46
-msgid "Women"
-msgstr "Femenino"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:47
-msgid "Non-Binary"
-msgstr "No binario"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:48
-msgid "Men"
-msgstr "Hombre"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:51
-msgid "women voted"
-msgstr "mujer votada"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:51
-#: .\decide\visualizer\templates\visualizer\ongoing.html:52
-#: .\decide\visualizer\templates\visualizer\ongoing.html:53
-msgid "of the total"
-msgstr "del total"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:52
-msgid "non-binary voted"
-msgstr "no binario votado"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:53
-msgid "men voted"
-msgstr "hombre votado"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:61
-msgid "to"
-msgstr "a"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:61
-#: .\decide\visualizer\templates\visualizer\ongoing.html:74
-#: .\decide\visualizer\templates\visualizer\ongoing.html:87
-msgid "years old"
-msgstr "años"
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:70
-msgid "The average age of people who voted is..."
-msgstr "La edad media de los votantes es..."
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:76
-msgid "Nobody has voted yet :("
-msgstr "Nadie ha votado aún :("
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:83
-msgid "The average age of people who didn't vote is..."
-msgstr "La edad media de los votantes que aún no han votado es..."
-
-#: .\decide\visualizer\templates\visualizer\ongoing.html:89
-msgid "Everyone has voted already :)"
-msgstr "Ya han votado todos :)"
-
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:5
-msgid "Voting is open"
-msgstr "La votación está abierta"
-
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:12
-msgid "Voter's Mean Age:"
-msgstr "Edad media del votante:"
-
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:15
-msgid "Non-Voter's Mean Age:"
-msgstr "Edad media del no votante:"
-
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:17
-msgid "Voter's Age Analysis:"
-msgstr "Análisis de edad del votante:"
-
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:24
-msgid "Women participation:"
-msgstr "Participación femenina:"
-
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:25
-msgid "Non-binary participation:"
-msgstr "Participación no binaria:"
-
-#: .\decide\visualizer\templates\visualizer\ongoing_export.html:26
-msgid "Men participation:"
-msgstr "Participación masculina:"
-
-#: .\decide\voting\templates\voting\openVotings.html:16
+#: .\visualizer\templates\visualizer\list_ended.html:21
+#: .\voting\templates\voting\openVotings.html:16
 msgid "Name"
 msgstr "Nombre"
 
-#: .\decide\voting\templates\voting\openVotings.html:17
+#: .\visualizer\templates\visualizer\list_ended.html:22
+#: .\voting\templates\voting\openVotings.html:17
 msgid "Description"
 msgstr "Descripción"
 
-#: .\decide\voting\templates\voting\openVotings.html:18
+#: .\visualizer\templates\visualizer\list_ended.html:23
+msgid "Question(s)"
+msgstr "Pregunta (s)"
+
+#: .\visualizer\templates\visualizer\list_ended.html:24
+msgid "Start/end"
+msgstr "Inicio/fin"
+
+#: .\visualizer\templates\visualizer\list_ended.html:25
+msgid "Link"
+msgstr "Enlace"
+
+#: .\visualizer\templates\visualizer\list_ended.html:50
+msgid "Started:"
+msgstr "Empezado:"
+
+#: .\visualizer\templates\visualizer\list_ended.html:51
+msgid "Ended:"
+msgstr "Terminado"
+
+#: .\visualizer\templates\visualizer\list_ended.html:55
+msgid "Go"
+msgstr "Ir"
+
+#: .\visualizer\templates\visualizer\list_ended.html:61
+msgid "There are no ended votings yet"
+msgstr "Aún no hay votaciones terminadas "
+
+#: .\visualizer\templates\visualizer\not_started.html:13
+msgid "Voting not started"
+msgstr "La votación no ha comenzado"
+
+#: .\visualizer\templates\visualizer\not_tally.html:12
+msgid "Votes have not been counted yet. Please try again later"
+msgstr "Los votos aún no han sido contados. Por favor, inténtelo de nuevo más tarde"
+
+#: .\visualizer\templates\visualizer\ongoing.html:12
+msgid "In Progress"
+msgstr "En progreso"
+
+#: .\visualizer\templates\visualizer\ongoing.html:19
+#: .\visualizer\templates\visualizer\ongoing_export.html:6
+#: .\voting\templates\voting\openVotings.html:19
+msgid "Stats"
+msgstr "Estadísticas"
+
+#: .\visualizer\templates\visualizer\ongoing.html:23
+#: .\visualizer\templates\visualizer\ongoing_export.html:8
+msgid "Census Size:"
+msgstr "Tamaño del censo"
+
+#: .\visualizer\templates\visualizer\ongoing.html:24
+#: .\visualizer\templates\visualizer\ongoing_export.html:9
+msgid "Voters Turnout:"
+msgstr "Asistencia de los votantes"
+
+#: .\visualizer\templates\visualizer\ongoing.html:25
+#: .\visualizer\templates\visualizer\ongoing_export.html:10
+msgid "Participation:"
+msgstr "Participación"
+
+#: .\visualizer\templates\visualizer\ongoing.html:40
+msgid "Interested in the participation according to genders? Check it out!"
+msgstr "¿Quieres saber la participación por género? ¡Míralo!"
+
+#: .\visualizer\templates\visualizer\ongoing.html:44
+msgid "Women"
+msgstr "Femenino"
+
+#: .\visualizer\templates\visualizer\ongoing.html:45
+msgid "Non-Binary"
+msgstr "No binario"
+
+#: .\visualizer\templates\visualizer\ongoing.html:46
+msgid "Men"
+msgstr "Hombre"
+
+#: .\visualizer\templates\visualizer\ongoing.html:49
+msgid "women voted"
+msgstr "mujer votada"
+
+#: .\visualizer\templates\visualizer\ongoing.html:49
+#: .\visualizer\templates\visualizer\ongoing.html:50
+#: .\visualizer\templates\visualizer\ongoing.html:51
+msgid "of the total"
+msgstr "del total"
+
+#: .\visualizer\templates\visualizer\ongoing.html:50
+msgid "non-binary voted"
+msgstr "no binario votado"
+
+#: .\visualizer\templates\visualizer\ongoing.html:51
+msgid "men voted"
+msgstr "hombre votado"
+
+#: .\visualizer\templates\visualizer\ongoing.html:59
+msgid "to"
+msgstr "a"
+
+#: .\visualizer\templates\visualizer\ongoing.html:59
+#: .\visualizer\templates\visualizer\ongoing.html:72
+#: .\visualizer\templates\visualizer\ongoing.html:85
+msgid "years old"
+msgstr "años"
+
+#: .\visualizer\templates\visualizer\ongoing.html:68
+msgid "The average age of people who voted is..."
+msgstr "La edad media de los votantes es..."
+
+#: .\visualizer\templates\visualizer\ongoing.html:74
+msgid "Nobody has voted yet :("
+msgstr "Nadie ha votado aún :("
+
+#: .\visualizer\templates\visualizer\ongoing.html:81
+msgid "The average age of people who didn't vote is..."
+msgstr "La edad media de los votantes que aún no han votado es..."
+
+#: .\visualizer\templates\visualizer\ongoing.html:87
+msgid "Everyone has voted already :)"
+msgstr "Ya han votado todos :)"
+
+#: .\visualizer\templates\visualizer\ongoing_export.html:5
+msgid "Voting is open"
+msgstr "La votación está abierta"
+
+#: .\visualizer\templates\visualizer\ongoing_export.html:12
+msgid "Voter's Mean Age:"
+msgstr "Edad media del votante:"
+
+#: .\visualizer\templates\visualizer\ongoing_export.html:15
+msgid "Non-Voter's Mean Age:"
+msgstr "Edad media del no votante:"
+
+#: .\visualizer\templates\visualizer\ongoing_export.html:17
+msgid "Voter's Age Analysis:"
+msgstr "Análisis de edad del votante:"
+
+#: .\visualizer\templates\visualizer\ongoing_export.html:24
+msgid "Women participation:"
+msgstr "Participación femenina:"
+
+#: .\visualizer\templates\visualizer\ongoing_export.html:25
+msgid "Non-binary participation:"
+msgstr "Participación no binaria:"
+
+#: .\visualizer\templates\visualizer\ongoing_export.html:26
+msgid "Men participation:"
+msgstr "Participación masculina:"
+
+#: .\voting\templates\voting\openVotings.html:18
 msgid "Booth"
 msgstr "Cabina"
 
-#: .\decide\voting\templates\voting\openVotings.html:30
+#: .\voting\templates\voting\openVotings.html:30
 msgid "Not provided."
 msgstr "No provisto."
 
-#: .\decide\voting\templates\voting\openVotings.html:33
+#: .\voting\templates\voting\openVotings.html:33
 msgid "Access to the booth"
 msgstr "Acceso a la cabina"
 
-#: .\decide\voting\templates\voting\openVotings.html:34
+#: .\voting\templates\voting\openVotings.html:34
 msgid "See the stats"
 msgstr "Ver las estadísticas"
 
-#: .\decide\voting\templates\voting\openVotings.html:42
+#: .\voting\templates\voting\openVotings.html:42
 msgid "There are no open votings in the system."
 msgstr "No hay votaciones abiertas en el sistema."
 

--- a/decide/locale/es/LC_MESSAGES/django.po
+++ b/decide/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-08 10:00+0000\n"
+"POT-Creation-Date: 2019-01-09 19:00+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,347 +17,372 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
-#: authentication/forms.py:13
+#: .\decide\authentication\forms.py:13
 msgid "Man"
 msgstr "Hombre"
 
-#: authentication/forms.py:14
+#: .\decide\authentication\forms.py:14
 msgid "Woman"
 msgstr "Mujer"
 
-#: authentication/forms.py:15
+#: .\decide\authentication\forms.py:15
 msgid "Non-binary"
 msgstr "No binario"
 
-#: authentication/forms.py:17
+#: .\decide\authentication\forms.py:17
 msgid "Format: dd/mm/YYYY"
 msgstr "Formato: dd/mm/YYYY"
 
-#: authentication/forms.py:19 authentication/models.py:17
+#: .\decide\authentication\forms.py:19 .\decide\authentication\models.py:17
 msgid "First name"
 msgstr "Nombre"
 
-#: authentication/forms.py:20 authentication/models.py:18
+#: .\decide\authentication\forms.py:20 .\decide\authentication\models.py:18
 msgid "Last name"
 msgstr "Apellidos"
 
-#: authentication/forms.py:21 authentication/models.py:16
-#: authentication/serializers.py:16
-#: authentication/templates/authentication/login.html:37
+#: .\decide\authentication\forms.py:21 .\decide\authentication\models.py:16
+#: .\decide\authentication\serializers.py:16
+#: .\decide\authentication\templates\authentication\login.html:37
 msgid "Email"
 msgstr "Correo electrónico"
 
-#: authentication/forms.py:22 authentication/models.py:19
+#: .\decide\authentication\forms.py:22 .\decide\authentication\models.py:19
 msgid "Birthdate"
 msgstr "Fecha de nacimiento"
 
-#: authentication/forms.py:23 authentication/models.py:20
+#: .\decide\authentication\forms.py:23 .\decide\authentication\models.py:20
 msgid "City"
 msgstr "Ciudad"
 
-#: authentication/forms.py:24 authentication/models.py:21
+#: .\decide\authentication\forms.py:24 .\decide\authentication\models.py:21
 msgid "Sex"
 msgstr "Sexo"
 
-#: authentication/forms.py:54
+#: .\decide\authentication\forms.py:54
 msgid "Email alredy exits"
 msgstr "El correo electrónico ya existe"
 
-#: authentication/forms.py:64
+#: .\decide\authentication\forms.py:64
 msgid "Future date not posible"
 msgstr "Fechas posteriores no validas"
 
-#: authentication/models.py:22
+#: .\decide\authentication\models.py:22
 msgid "Is active"
 msgstr "Está activo"
 
-#: authentication/models.py:23
+#: .\decide\authentication\models.py:23
 msgid "Is staf"
 msgstr "Es personal autorizado"
 
-#: authentication/schemas/inspectors.py:114
+#: .\decide\authentication\schemas\inspectors.py:114
 msgid "unique integer value"
 msgstr "unique integer value"
 
-#: authentication/schemas/inspectors.py:116
+#: .\decide\authentication\schemas\inspectors.py:116
 msgid "UUID string"
 msgstr "UUID string"
 
-#: authentication/schemas/inspectors.py:118
+#: .\decide\authentication\schemas\inspectors.py:118
 msgid "unique value"
 msgstr "unique value"
 
-#: authentication/schemas/inspectors.py:120
+#: .\decide\authentication\schemas\inspectors.py:120
 #, python-brace-format
 msgid "A {value_type} identifying this {name}."
 msgstr "A {value_type} identifying this {name}."
 
-#: authentication/serializers.py:18
-#: authentication/templates/authentication/login.html:45
+#: .\decide\authentication\serializers.py:18
+#: .\decide\authentication\templates\authentication\login.html:45
 msgid "Password"
 msgstr "Contraseña"
 
-#: authentication/serializers.py:32
+#: .\decide\authentication\serializers.py:32
 msgid "Unable to log in with provided credentials."
-msgstr "No se puede iniciar sesión con las credenciales provistas"
+msgstr "No se puede iniciar sesión con las credenciales provistas."
 
-#: authentication/serializers.py:35
+#: .\decide\authentication\serializers.py:35
 msgid "Must include \"email\" and \"password\"."
 msgstr "Debe incluir \"email\" and \"contraseña\"."
 
-#: authentication/templates/authentication/acc_active_email.html:3
-#: authentication/templates/authentication/confirm_email.html:4
+#: .\decide\authentication\templates\authentication\acc_active_email.html:3
+#: .\decide\authentication\templates\authentication\confirm_email.html:4
 msgid "New user"
 msgstr "Nuev@ usuari@"
 
-#: authentication/templates/authentication/acc_active_email.html:9
+#: .\decide\authentication\templates\authentication\acc_active_email.html:9
 msgid "Thank you for your email confirmation. Now you can login your account."
-msgstr ""
-"Gracias por la confirmación del correo electrónico. Ahora puedes iniciar la "
-"sesión de tu cuenta."
+msgstr "Gracias por la confirmación del correo electrónico. Ahora puedes iniciar la sesión de tu cuenta."
 
-#: authentication/templates/authentication/acc_active_email.html:11
+#: .\decide\authentication\templates\authentication\acc_active_email.html:11
 msgid "Go to login"
-msgstr "Iniciar sesión"
+msgstr "Iniciar Sesión"
 
-#: authentication/templates/authentication/confirm_email.html:7
+#: .\decide\authentication\templates\authentication\confirm_email.html:7
 msgid "Please confirm your email address to complete the registration"
-msgstr ""
-"Por favor, confirme su dirección de correo electrónico para completar el "
-"registro"
+msgstr "Por favor, confirme su dirección de correo electrónico para completar el registro"
 
-#: authentication/templates/authentication/login.html:25
+#: .\decide\authentication\templates\authentication\login.html:25
 msgid "Log in"
 msgstr "Iniciar Sesión"
 
-#: authentication/templates/authentication/login.html:50
+#: .\decide\authentication\templates\authentication\login.html:50
 msgid "Login"
 msgstr "Iniciar Sesión"
 
-#: authentication/templates/authentication/login.html:93
+#: .\decide\authentication\templates\authentication\login.html:93
 msgid "Enter an email and a password."
 msgstr "Introduzca un correo electrónico y una contraseña."
 
-#: authentication/templates/authentication/login.html:105
+#: .\decide\authentication\templates\authentication\login.html:105
 msgid "Error: The credentials are not valid"
 msgstr "Error: Las credenciales no son válidas"
 
-#: authentication/templates/authentication/login.html:108
-#: booth/templates/booth/booth.html:312
+#: .\decide\authentication\templates\authentication\login.html:108
+#: .\decide\booth\templates\booth\booth.html:312
 msgid "Error: "
-msgstr "Error: "
+msgstr "Error"
 
-#: authentication/templates/authentication/signup.html:7
+#: .\decide\authentication\templates\authentication\signup.html:7
 msgid "Sign up a new user"
 msgstr "Registrar nuev@ usuari@"
 
-#: authentication/templates/authentication/signup.html:15
+#: .\decide\authentication\templates\authentication\signup.html:15
 msgid "Submit"
 msgstr "Enviar"
 
-#: base/templates/base.html:165
-msgid "Footer Content"
-msgstr "Contenido de Pie de página"
+#: .\decide\base\templates\base.html:125
+#: .\decide\voting\templates\voting\openVotings.html:9
+msgid "Open Votings"
+msgstr "Votaciones Abiertas"
 
-#: base/templates/base.html:166
+#: .\decide\base\templates\base.html:165
+msgid "Footer Content"
+msgstr "Contenido de pie de página"
+
+#: .\decide\base\templates\base.html:166
 msgid "Information."
 msgstr "Información."
 
-#: base/templates/base.html:172
+#: .\decide\base\templates\base.html:172
 msgid "© 2018 Copyright Text"
 msgstr "© 2018 Copyright Text"
 
-#: base/templates/base.html:173
+#: .\decide\base\templates\base.html:173
 msgid "More Links"
-msgstr "Mas hipervínculos"
+msgstr "Más enlaces"
 
-#: base/templates/index.html:12
+#: .\decide\base\templates\index.html:12
 msgid "Welcome"
 msgstr "Bienvenid@"
 
-#: booth/templates/booth/booth.html:21
+#: .\decide\booth\templates\booth\booth.html:21
 msgid "The voting can not be accessed because it has not started."
 msgstr "No se puede acceder a la votación porque no ha comenzado."
 
-#: booth/templates/booth/booth.html:23
+#: .\decide\booth\templates\booth\booth.html:23
 msgid ""
 "The voting can not be accessed because it has ended. You can access to the "
 "results in the following link: "
-msgstr ""
-"No se puede acceder a la votación porque ya ha terminado. Puedes acceder al "
-"resultado en el siguiente link:"
+msgstr "No se puede acceder a la votación porque ya ha terminado. Puedes acceder al resultado en el siguiente link:"
 
-#: booth/templates/booth/booth.html:23
+#: .\decide\booth\templates\booth\booth.html:23
 msgid "Results"
 msgstr "Resultados"
 
-#: booth/templates/booth/booth.html:25
+#: .\decide\booth\templates\booth\booth.html:25
 msgid ""
 "This vote does not contain any questions, so it can not be accessed yet. Try "
 "it again later."
-msgstr ""
-"Esta votación no contiene preguntas, por lo que aún no se puede acceder. "
-"Inténtalo de nuevo más tarde."
+msgstr "Esta votación no contiene preguntas, por lo que aún no se puede acceder. Inténtalo de nuevo más tarde."
 
-#: booth/templates/booth/booth.html:66
+#: .\decide\booth\templates\booth\booth.html:66
 msgid "Answer with voice"
 msgstr "Responder con voz"
 
-#: booth/templates/booth/booth.html:75
+#: .\decide\booth\templates\booth\booth.html:75
 msgid "Send vote"
 msgstr "Enviar voto"
 
-#: booth/templates/booth/booth.html:85
+#: .\decide\booth\templates\booth\booth.html:85
 msgid "Speech Synthesis not supported"
 msgstr "Síntesis de voz no soportada"
 
-#: booth/templates/booth/booth.html:86
+#: .\decide\booth\templates\booth\booth.html:86
 msgid "Your browser does not support speech synthesis."
 msgstr "Su navegador no soporta la síntesis de voz."
 
-#: booth/templates/booth/booth.html:87
+#: .\decide\booth\templates\booth\booth.html:87
 msgid "We recommend you use Google Chrome."
 msgstr "Le recomendamos utilizar Google Chrome."
 
-#: booth/templates/booth/booth.html:309
+#: .\decide\booth\templates\booth\booth.html:309
 msgid "Congratulations. Your vote has been sent"
 msgstr "Felicidades. Tu voto ha sido enviado."
 
-#: booth/templates/booth/booth.html:317
+#: .\decide\booth\templates\booth\booth.html:317
 msgid "You must select an option for each question."
 msgstr "Debes seleccionar una opción para cada pregunta."
 
-#: visualizer/templates/visualizer/ended.html:15
-#: visualizer/templates/visualizer/ended_export.html:6
+#: .\decide\visualizer\templates\visualizer\ended.html:15
+#: .\decide\visualizer\templates\visualizer\ended_export.html:6
 msgid "Results: "
 msgstr "Resultados"
 
-#: visualizer/templates/visualizer/ended.html:152
-#: visualizer/templates/visualizer/ongoing.html:95
+#: .\decide\visualizer\templates\visualizer\ended.html:152
+#: .\decide\visualizer\templates\visualizer\ongoing.html:95
 msgid "Download results as .pdf"
 msgstr "Descargar los resultados en formato .pdf"
 
-#: visualizer/templates/visualizer/ended.html:154
-#: visualizer/templates/visualizer/ongoing.html:97
+#: .\decide\visualizer\templates\visualizer\ended.html:154
+#: .\decide\visualizer\templates\visualizer\ongoing.html:97
 msgid "Download results as .csv"
 msgstr "Descargar los resultados en formato .csv"
 
-#: visualizer/templates/visualizer/not_started.html:16
+#: .\decide\visualizer\templates\visualizer\not_started.html:16
 msgid "Voting not started"
 msgstr "La votación no ha comenzado"
 
-#: visualizer/templates/visualizer/ongoing.html:14
+#: .\decide\visualizer\templates\visualizer\ongoing.html:14
 msgid "In Progress"
 msgstr "En progreso"
 
-#: visualizer/templates/visualizer/ongoing.html:21
-#: visualizer/templates/visualizer/ongoing_export.html:6
+#: .\decide\visualizer\templates\visualizer\ongoing.html:21
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:6
+#: .\decide\voting\templates\voting\openVotings.html:19
 msgid "Stats"
 msgstr "Estadisticas"
 
-#: visualizer/templates/visualizer/ongoing.html:25
-#: visualizer/templates/visualizer/ongoing_export.html:8
+#: .\decide\visualizer\templates\visualizer\ongoing.html:25
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:8
 msgid "Census Size:"
 msgstr "Tamaño del censo"
 
-#: visualizer/templates/visualizer/ongoing.html:26
-#: visualizer/templates/visualizer/ongoing_export.html:9
+#: .\decide\visualizer\templates\visualizer\ongoing.html:26
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:9
 msgid "Voters Turnout:"
 msgstr "Asistencia de los votantes"
 
-#: visualizer/templates/visualizer/ongoing.html:27
-#: visualizer/templates/visualizer/ongoing_export.html:10
+#: .\decide\visualizer\templates\visualizer\ongoing.html:27
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:10
 msgid "Participation:"
 msgstr "Participación"
 
-#: visualizer/templates/visualizer/ongoing.html:42
+#: .\decide\visualizer\templates\visualizer\ongoing.html:42
 msgid "Interested in the participation according to genders? Check it out!"
 msgstr "¿Quieres saber la participación por género? ¡Míralo!"
 
-#: visualizer/templates/visualizer/ongoing.html:46
+#: .\decide\visualizer\templates\visualizer\ongoing.html:46
 msgid "Women"
 msgstr "Femenino"
 
-#: visualizer/templates/visualizer/ongoing.html:47
+#: .\decide\visualizer\templates\visualizer\ongoing.html:47
 msgid "Non-Binary"
 msgstr "No binario"
 
-#: visualizer/templates/visualizer/ongoing.html:48
+#: .\decide\visualizer\templates\visualizer\ongoing.html:48
 msgid "Men"
 msgstr "Hombre"
 
-#: visualizer/templates/visualizer/ongoing.html:51
+#: .\decide\visualizer\templates\visualizer\ongoing.html:51
 msgid "women voted"
 msgstr "mujer votada"
 
-#: visualizer/templates/visualizer/ongoing.html:51
-#: visualizer/templates/visualizer/ongoing.html:52
-#: visualizer/templates/visualizer/ongoing.html:53
+#: .\decide\visualizer\templates\visualizer\ongoing.html:51
+#: .\decide\visualizer\templates\visualizer\ongoing.html:52
+#: .\decide\visualizer\templates\visualizer\ongoing.html:53
 msgid "of the total"
 msgstr "del total"
 
-#: visualizer/templates/visualizer/ongoing.html:52
+#: .\decide\visualizer\templates\visualizer\ongoing.html:52
 msgid "non-binary voted"
 msgstr "no binario votado"
 
-#: visualizer/templates/visualizer/ongoing.html:53
+#: .\decide\visualizer\templates\visualizer\ongoing.html:53
 msgid "men voted"
 msgstr "hombre votado"
 
-#: visualizer/templates/visualizer/ongoing.html:61
+#: .\decide\visualizer\templates\visualizer\ongoing.html:61
 msgid "to"
 msgstr "a"
 
-#: visualizer/templates/visualizer/ongoing.html:61
-#: visualizer/templates/visualizer/ongoing.html:74
-#: visualizer/templates/visualizer/ongoing.html:87
+#: .\decide\visualizer\templates\visualizer\ongoing.html:61
+#: .\decide\visualizer\templates\visualizer\ongoing.html:74
+#: .\decide\visualizer\templates\visualizer\ongoing.html:87
 msgid "years old"
 msgstr "años"
 
-#: visualizer/templates/visualizer/ongoing.html:70
+#: .\decide\visualizer\templates\visualizer\ongoing.html:70
 msgid "The average age of people who voted is..."
 msgstr "La edad media de los votantes es..."
 
-#: visualizer/templates/visualizer/ongoing.html:76
+#: .\decide\visualizer\templates\visualizer\ongoing.html:76
 msgid "Nobody has voted yet :("
 msgstr "Nadie ha votado aún :("
 
-#: visualizer/templates/visualizer/ongoing.html:83
+#: .\decide\visualizer\templates\visualizer\ongoing.html:83
 msgid "The average age of people who didn't vote is..."
 msgstr "La edad media de los votantes que aún no han votado es..."
 
-#: visualizer/templates/visualizer/ongoing.html:89
+#: .\decide\visualizer\templates\visualizer\ongoing.html:89
 msgid "Everyone has voted already :)"
 msgstr "Ya han votado todos :)"
 
-#: visualizer/templates/visualizer/ongoing_export.html:5
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:5
 msgid "Voting is open"
 msgstr "La votación está abierta"
 
-#: visualizer/templates/visualizer/ongoing_export.html:12
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:12
 msgid "Voter's Mean Age:"
-msgstr "Edad media de los no votantes:"
+msgstr "Edad media del votante:"
 
-#: visualizer/templates/visualizer/ongoing_export.html:15
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:15
 msgid "Non-Voter's Mean Age:"
-msgstr "Edad media de los no votantes:"
+msgstr "Edad media del no votante:"
 
-#: visualizer/templates/visualizer/ongoing_export.html:17
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:17
 msgid "Voter's Age Analysis:"
-msgstr "Analisis de la edad de los votantes:"
+msgstr "Análisis de edad del votante:"
 
-#: visualizer/templates/visualizer/ongoing_export.html:24
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:24
 msgid "Women participation:"
 msgstr "Participación femenina:"
 
-#: visualizer/templates/visualizer/ongoing_export.html:25
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:25
 msgid "Non-binary participation:"
-msgstr "Participación de genéro no binario:"
+msgstr "Participación no binaria:"
 
-#: visualizer/templates/visualizer/ongoing_export.html:26
+#: .\decide\visualizer\templates\visualizer\ongoing_export.html:26
 msgid "Men participation:"
 msgstr "Participación masculina:"
+
+#: .\decide\voting\templates\voting\openVotings.html:16
+msgid "Name"
+msgstr "Nombre"
+
+#: .\decide\voting\templates\voting\openVotings.html:17
+msgid "Description"
+msgstr "Descripción"
+
+#: .\decide\voting\templates\voting\openVotings.html:18
+msgid "Booth"
+msgstr "Cabina"
+
+#: .\decide\voting\templates\voting\openVotings.html:30
+msgid "Not provided."
+msgstr "No provisto."
+
+#: .\decide\voting\templates\voting\openVotings.html:33
+msgid "Access to the booth"
+msgstr "Acceso a la cabina"
+
+#: .\decide\voting\templates\voting\openVotings.html:34
+msgid "See the stats"
+msgstr "Ver las estadísticas"
+
+#: .\decide\voting\templates\voting\openVotings.html:42
+msgid "There are no open votings in the system."
+msgstr "No hay votaciones abiertas en el sistema."
 
 #: .\decide\settings.py:148
 msgid "English"

--- a/decide/voting/templates/voting/openVotings.html
+++ b/decide/voting/templates/voting/openVotings.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+{% load i18n static %}
+{% load custom_tags %}
+{% block extrahead %}
+    <link type="text/css" rel="stylesheet" href="{% static 'decide/css/voting/voting.css'%}"/>
+{% endblock %}
+{% block content %}
+
+	<h3 class="center-align titulo">Open votings</h3><br>
+	
+	{% if open_votings %}
+	
+		<table class="table table-striped table-bordered">
+    		<thead>
+		    	<tr>
+		    		<th>{% trans 'Name' %}</th>
+		    		<th>{% trans 'Description' %}</th>
+		    		<th>{% trans 'Booth' %}</th>
+		    		<th>{% trans 'Stats' %}</th>
+		    	</tr>
+		    </thead>
+		    <tbody>
+		    	{% for open_voting in open_votings %}
+		    		<tr>
+		    			<td>{{open_voting.name}}</td>
+		    			<td>
+		    				{% if open_voting.desc %}
+		    					{{open_voting.desc}}
+		    				{% else %}
+		    					{% trans 'Not provided.' %}
+		    				{% endif %}
+		    			</td>
+		    			<td><a href="/booth/{{open_voting.id}}">{% trans 'Access to the booth' %}</a></td>
+		    			<td><a href="/visualizer/{{open_voting.id}}">{% trans 'See the stats' %}</a></td>
+		    		</tr>
+		    	{% endfor %}
+	    	</tbody>
+		</table>
+		
+	{% else %}
+    
+    	<p class="center-align flow-text mensajes">{% trans 'There are no open votings in the system.' %}</p>
+    	
+    {% endif %}
+    
+{% endblock %}

--- a/decide/voting/templates/voting/openVotings.html
+++ b/decide/voting/templates/voting/openVotings.html
@@ -6,7 +6,7 @@
 {% endblock %}
 {% block content %}
 
-	<h3 class="center-align titulo">Open votings</h3><br>
+	<h3 class="center-align titulo">{% trans 'Open Votings' %}</h3><br>
 	
 	{% if open_votings %}
 	

--- a/decide/voting/templates/voting/openVotings.html
+++ b/decide/voting/templates/voting/openVotings.html
@@ -6,7 +6,7 @@
 {% endblock %}
 {% block content %}
 
-	<h3 class="center-align titulo">{% trans 'Open Votings' %}</h3><br>
+	<h3 class="center-align titulo">{% trans 'Open votings' %}</h3><br>
 	
 	{% if open_votings %}
 	

--- a/decide/voting/urls.py
+++ b/decide/voting/urls.py
@@ -5,4 +5,5 @@ from . import views
 urlpatterns = [
     path('', views.VotingView.as_view(), name='voting'),
     path('<int:voting_id>/', views.VotingUpdate.as_view(), name='voting'),
+    path('openVotings/', views.get_open_votings, name="openVotings"),
 ]

--- a/decide/voting/views.py
+++ b/decide/voting/views.py
@@ -1,7 +1,7 @@
 import django_filters.rest_framework
 from django.conf import settings
 from django.utils import timezone
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, render
 from rest_framework import generics, status
 from rest_framework.response import Response
 
@@ -104,3 +104,18 @@ class VotingUpdate(generics.RetrieveUpdateDestroyAPIView):
             msg = 'Action not found, try with start, stop or tally'
             st = status.HTTP_400_BAD_REQUEST
         return Response(msg, status=st)
+
+def get_open_votings(request):
+    
+    """
+    Method to get all open votings (all votings that have
+    start date and dont have end date.
+    """
+    
+    try:
+        open_votings = Voting.objects.filter(start_date__isnull = False, end_date__isnull = True)
+    except:
+        open_votings = []
+    
+    return render(request, 'voting/openVotings.html',
+                  context={'open_votings':open_votings})


### PR DESCRIPTION
#### ¿Que hace este pull request?

Este pull request implementa un listado de votaciones abiertas, siendo estas aquellas votaciones con fecha de inicio no nula y fecha de fin nula. Este listado es accesible a través de la barra de navegación, pulsando sobre la opción _Votaciones abiertas_. El listado incluye, para cada votación, el nombre de la votación, la descripción, un enlace para acceder a la cabina y un enlace para visualizar las estadísticas. Además, se han actualizados los archivos _.po_ del sistema para incluir nuevos mensajes. Este pull request esta relacionado con la _Issue_ decide-ganimedes/decide-ganimedes#64.

#### Pasos para la realización de pruebas

1. Iniciar sesión en la página de administrador de Django y crear tres votaciones, una de ellas sin descripción. Añadir preguntas y opciones a alguna de las votaciones creadas anteriormente.
2. Asignar al superusuario a las votaciones mediante censos.
3. Verificar que el listado de votaciones no muestra ninguna votación.
4. Iniciar alguna de las votaciones y verificar que el listado solo muestra las votaciones inciadas. Una vez verificado, iniciar el resto de votaciones que no fueron iniciadas anteriormente y verificar que todas se muestran. Verificar que en la descripción de la votación sin descripción aparece _No provisto_.
5. Cerrar aquellas votaciones y dejar, al menos, una votación que tenga preguntas y opciones. Verificar que las votaciones cerradas no se muestran en el listado.
6. Pulsar sobre el enlace para ir a la cabina de alguna de las votaciones que tenga preguntas y opciones. Verificar que se ha llegado a la cabina de votación correcta.

_IMPORTANTE: El enlace para visualizar los resultados no funciona correctamente, ya que el módulo de visualización tiene que subir sus cambios._